### PR TITLE
Feature/predict-setlist-use-ai

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,7 @@ dependencies {
 
     implementation 'com.h2database:h2'
 
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 }
 
 

--- a/src/main/java/com/bopcon/backend/api/GeminiApiClient.java
+++ b/src/main/java/com/bopcon/backend/api/GeminiApiClient.java
@@ -1,0 +1,49 @@
+package com.bopcon.backend.api;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Component
+@RequiredArgsConstructor
+public class GeminiApiClient {
+
+    private final WebClient.Builder webClientBuilder;
+    private final ObjectMapper objectMapper;
+
+    @Value("${gemini.api.key}")
+    private String apiKey;
+
+    @Value("${gemini.api.url}")
+    private String apiUrl;
+
+    public JsonNode generatePredictedSetlist(String prompt) {
+        try {
+            // 요청 데이터 생성
+            ObjectMapper mapper = new ObjectMapper();
+            JsonNode requestJson = mapper.createObjectNode()
+                    .set("contents", mapper.createArrayNode()
+                            .add(mapper.createObjectNode()
+                                    .set("parts", mapper.createArrayNode()
+                                            .add(mapper.createObjectNode().put("text", prompt)))));
+
+            // WebClient 요청
+            String response = webClientBuilder.build()
+                    .post()
+                    .uri(apiUrl)
+                    .header("Content-Type", "application/json")
+                    .header("X-goog-api-key", apiKey)
+                    .bodyValue(mapper.writeValueAsString(requestJson))
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .block();
+            System.out.println(response);
+            return mapper.readTree(response); // 응답 JSON 파싱
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to call Gemini API", e);
+        }
+    }
+}

--- a/src/main/java/com/bopcon/backend/config/JacksonConfig.java
+++ b/src/main/java/com/bopcon/backend/config/JacksonConfig.java
@@ -1,0 +1,17 @@
+package com.bopcon.backend.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule()); // Java 8 Date/Time 타입 처리 모듈 등록
+        return mapper;
+    }
+}

--- a/src/main/java/com/bopcon/backend/controller/ArtistApiController.java
+++ b/src/main/java/com/bopcon/backend/controller/ArtistApiController.java
@@ -73,4 +73,11 @@ public class ArtistApiController {
         List<SongRankingDTO> songRanking = artistService.getSongRankingByArtist(artistId);
         return ResponseEntity.ok(songRanking);
     }
+
+    // 특정 아티스트의 과거 콘서트 셋리스트 반환
+    @GetMapping("/api/artists/{artistId}/past-setlists")
+    public ResponseEntity<List<PastConcertSetlistDTO>> getPastConcertSetlists(@PathVariable Long artistId) {
+        List<PastConcertSetlistDTO> setlists = artistService.getPastConcertSetlistsByArtist(artistId);
+        return ResponseEntity.ok(setlists);
+    }
 }

--- a/src/main/java/com/bopcon/backend/domain/PredictSetlist.java
+++ b/src/main/java/com/bopcon/backend/domain/PredictSetlist.java
@@ -1,0 +1,32 @@
+package com.bopcon.backend.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PredictSetlist {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "new_concert_id", nullable = false)
+    private NewConcert newConcert;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "song_id", nullable = false)
+    private Song song;
+
+    @Column(name = "`order`", nullable = false)
+    private Integer order;
+
+    @Builder
+    public PredictSetlist(NewConcert newConcert, Song song, Integer order) {
+        this.newConcert = newConcert;
+        this.song = song;
+        this.order = order;
+    }
+}

--- a/src/main/java/com/bopcon/backend/dto/PastConcertSetlistDTO.java
+++ b/src/main/java/com/bopcon/backend/dto/PastConcertSetlistDTO.java
@@ -1,0 +1,16 @@
+package com.bopcon.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class PastConcertSetlistDTO {
+    private LocalDate date; // 콘서트 날짜
+    private String songTitle; // 곡 이름
+    private Integer order; // 곡 순서
+}

--- a/src/main/java/com/bopcon/backend/dto/PastConcertSetlistDTO.java
+++ b/src/main/java/com/bopcon/backend/dto/PastConcertSetlistDTO.java
@@ -1,5 +1,6 @@
 package com.bopcon.backend.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,6 +11,7 @@ import java.time.LocalDate;
 @AllArgsConstructor
 @NoArgsConstructor
 public class PastConcertSetlistDTO {
+    @JsonFormat(pattern = "yyyy-MM-dd") // JSON 날짜 형식 지정
     private LocalDate date; // 콘서트 날짜
     private String songTitle; // 곡 이름
     private Integer order; // 곡 순서

--- a/src/main/java/com/bopcon/backend/dto/PredictSetlistDTO.java
+++ b/src/main/java/com/bopcon/backend/dto/PredictSetlistDTO.java
@@ -1,0 +1,13 @@
+package com.bopcon.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PredictSetlistDTO {
+    private String songTitle;
+    private Integer order;
+    private String lyrics;
+    private String ytLink;
+}

--- a/src/main/java/com/bopcon/backend/dto/SetlistDTO.java
+++ b/src/main/java/com/bopcon/backend/dto/SetlistDTO.java
@@ -8,16 +8,16 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 public class SetlistDTO {
-    private Integer order;
     private Long concertSetlistId;
+    private Integer order;
     private Long concertId;
     private String concertType; // "past" 또는 "new"로 구분
     private SongDTO song;
 
     public static SetlistDTO fromEntity(ConcertSetlist concertSetlist){
         return new SetlistDTO(
-                concertSetlist.getOrder(),
                 concertSetlist.getConcertSetlistId(),
+                concertSetlist.getOrder(),
                 concertSetlist.getPastConcert() != null
                     ? concertSetlist.getPastConcert().getPastConcertId()
                         : concertSetlist.getNewConcert().getNewConcertId(),

--- a/src/main/java/com/bopcon/backend/repository/PastConcertRepository.java
+++ b/src/main/java/com/bopcon/backend/repository/PastConcertRepository.java
@@ -3,7 +3,10 @@ package com.bopcon.backend.repository;
 
 import com.bopcon.backend.domain.Artist;
 import com.bopcon.backend.domain.PastConcert;
+import com.bopcon.backend.dto.PastConcertSetlistDTO;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
@@ -13,4 +16,12 @@ import java.util.Optional;
 @Repository
 public interface PastConcertRepository extends JpaRepository<PastConcert, Long> {
     List<PastConcert> findAllByArtist_ArtistId(Long artistId);
+
+    // 날짜와 셋리스트 정보 가져오기
+    @Query("SELECT new com.bopcon.backend.dto.PastConcertSetlistDTO(pc.date, cs.song.title, cs.order) " +
+            "FROM PastConcert pc " +
+            "JOIN pc.setlists cs " +
+            "WHERE pc.artist.artistId = :artistId " +
+            "ORDER BY pc.date ASC, cs.order ASC")
+    List<PastConcertSetlistDTO> findConcertSetlistsByArtistId(@Param("artistId") Long artistId);
 }

--- a/src/main/java/com/bopcon/backend/repository/PredictSetlistRepository.java
+++ b/src/main/java/com/bopcon/backend/repository/PredictSetlistRepository.java
@@ -1,0 +1,10 @@
+package com.bopcon.backend.repository;
+
+import com.bopcon.backend.domain.PredictSetlist;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PredictSetlistRepository extends JpaRepository<PredictSetlist, Long> {
+    List<PredictSetlist> findAllByNewConcert_NewConcertId(Long newConcertId);
+}

--- a/src/main/java/com/bopcon/backend/service/ArtistService.java
+++ b/src/main/java/com/bopcon/backend/service/ArtistService.java
@@ -5,10 +5,7 @@ import com.bopcon.backend.domain.Artist;
 import com.bopcon.backend.domain.ConcertSetlist;
 import com.bopcon.backend.domain.PastConcert;
 import com.bopcon.backend.domain.Song;
-import com.bopcon.backend.dto.AddArtistRequest;
-import com.bopcon.backend.dto.PastConcertDTO;
-import com.bopcon.backend.dto.SongRankingDTO;
-import com.bopcon.backend.dto.UpdateArtistRequest;
+import com.bopcon.backend.dto.*;
 import com.bopcon.backend.repository.*;
 import com.fasterxml.jackson.databind.JsonNode;
 import jakarta.persistence.EntityNotFoundException;
@@ -132,5 +129,11 @@ public class ArtistService {
     @Transactional
     public List<SongRankingDTO> getSongRankingByArtist(Long artistId) {
         return concertSetlistRepository.findSongRankingByArtistId(artistId);
+    }
+
+    // 특정 아티스트의 과거 콘서트 셋리스트 반환
+    @Transactional
+    public List<PastConcertSetlistDTO> getPastConcertSetlistsByArtist(Long artistId) {
+        return pastConcertRepository.findConcertSetlistsByArtistId(artistId);
     }
 }


### PR DESCRIPTION
- 아티스트 과거 셋리스트 불러오기 (예상셋리스트 생성용)
- Gemini 설정, 예상 셋리스트 생성 및 저장 기능

최근 20개 콘서트 셋리스트를 Gemini에게 주어 예상셋리스트를 생성한 뒤 데이터베이스에 저장.
Song테이블과 연결하여 유튜브 링크 및 가사 접근가능
