### PR TITLE
날짜 저장 방식 변경 ( 기존 날짜 한 개 에서 시작 날짜 종료 날짜로)

### DIFF
--- a/src/main/java/com/bopcon/backend/domain/NewConcert.java
+++ b/src/main/java/com/bopcon/backend/domain/NewConcert.java
@@ -7,6 +7,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.cglib.core.Local;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDate;
@@ -33,8 +34,11 @@ public class NewConcert {
     @Column(name = "sub_title", length = 100)
     private String subTitle;
 
-    @Column(name = "date", nullable = false)
-    private LocalDate date;
+    @Column(name = "start_date", nullable = false)
+    private LocalDate startDate;
+
+    @Column(name = "end_date", nullable = false)
+    private LocalDate endDate;
 
     @Column(name = "venue_name", nullable = false, length = 100)
     private String venueName; // 공연장
@@ -76,14 +80,15 @@ public class NewConcert {
     }
 
     @Builder
-    public NewConcert(Artist artistId, String title, String subTitle, LocalDate date,
+    public NewConcert(Artist artistId, String title, String subTitle, LocalDate startDate, LocalDate endDate,
                       String venueName, String cityName, String countryName,
                       String countryCode, String ticketPlatforms, String ticketUrl,
                       String posterUrl, String genre, ConcertStatus concertStatus){
         this.artist = artistId;
         this.title = title;
         this.subTitle = subTitle;
-        this.date = date;
+        this.startDate = startDate;
+        this.endDate = endDate;
         this.venueName = venueName;
         this.cityName = cityName;
         this.countryName = countryName;
@@ -99,7 +104,8 @@ public class NewConcert {
         this.artist = artist;
         this.title = request.getTitle();
         this.subTitle = request.getSubTitle();
-        this.date = request.getDate();
+        this.startDate = request.getStartDate();
+        this.endDate = request.getEndDate();
         this.venueName = request.getVenueName();
         this.cityName = request.getCityName();
         this.countryName = request.getCountryName();

--- a/src/main/java/com/bopcon/backend/dto/AddNewConcertRequest.java
+++ b/src/main/java/com/bopcon/backend/dto/AddNewConcertRequest.java
@@ -16,7 +16,8 @@ public class AddNewConcertRequest {
     private Long artistId;
     private String title;
     private String subTitle;
-    private LocalDate date;
+    private LocalDate startDate;
+    private LocalDate endDate;
     private String venueName; // 공연장
     private String cityName;
     private String countryName; // ex) Republic of Korea
@@ -32,7 +33,8 @@ public class AddNewConcertRequest {
                 .artistId(artist)
                 .title(title)
                 .subTitle(subTitle)
-                .date(date)
+                .startDate(startDate)
+                .endDate(endDate)
                 .venueName(venueName)
                 .cityName(cityName)
                 .countryName(countryName)

--- a/src/main/java/com/bopcon/backend/dto/NewConcertResponse.java
+++ b/src/main/java/com/bopcon/backend/dto/NewConcertResponse.java
@@ -15,7 +15,8 @@ public class NewConcertResponse {
     private Long artistId;
     private String title;
     private String subTitle;
-    private LocalDate date;
+    private LocalDate startDate;
+    private LocalDate endDate;
     private String venueName; // 공연장
     private String cityName;
     private String countryName; // ex) Republic of Korea
@@ -33,7 +34,8 @@ public class NewConcertResponse {
                 newConcert.getArtistId() != null ? newConcert.getArtistId().getArtistId() : null, // Null 처리
                 newConcert.getTitle(),
                 newConcert.getSubTitle(),
-                newConcert.getDate(),
+                newConcert.getStartDate(),
+                newConcert.getEndDate(),
                 newConcert.getVenueName(),
                 newConcert.getCityName(),
                 newConcert.getCountryName(),
@@ -53,7 +55,8 @@ public class NewConcertResponse {
         this.artistId = newConcert.getArtistId() != null ? newConcert.getArtistId().getArtistId() : null; // Null 처리
         this.title = newConcert.getTitle();
         this.subTitle = newConcert.getSubTitle();
-        this.date = newConcert.getDate();
+        this.startDate = newConcert.getStartDate();
+        this.endDate = newConcert.getEndDate();
         this.venueName = newConcert.getVenueName();
         this.cityName = newConcert.getCityName();
         this.countryName = newConcert.getCountryName();

--- a/src/main/java/com/bopcon/backend/dto/NewConcertSimpleResponse.java
+++ b/src/main/java/com/bopcon/backend/dto/NewConcertSimpleResponse.java
@@ -11,7 +11,8 @@ public class NewConcertSimpleResponse {
     private final Long artistId;
     private final String artistName;
     private final String title;
-    private final LocalDate date;
+    private final LocalDate startDate;
+    private final LocalDate endDate;
 
 
     public NewConcertSimpleResponse(NewConcert newConcert){
@@ -19,6 +20,7 @@ public class NewConcertSimpleResponse {
         this.artistId = newConcert.getArtist().getArtistId();
         this.artistName = newConcert.getArtist().getName();
         this.title = newConcert.getTitle();
-        this.date = newConcert.getDate();
+        this.startDate = newConcert.getStartDate();
+        this.endDate = newConcert.getEndDate();
     }
 }

--- a/src/main/java/com/bopcon/backend/dto/SearchResponse.java
+++ b/src/main/java/com/bopcon/backend/dto/SearchResponse.java
@@ -16,7 +16,8 @@ public class SearchResponse {
         private final Long newConcertId;
         private final String title;
         private final String subTitle;
-        private final String date;
+        private final String startDate;
+        private final String endDate;
         private final String venueName;
         private final String cityName;
         private final String countryName;
@@ -36,7 +37,8 @@ public class SearchResponse {
             this.newConcertId = concert.getNewConcertId();
             this.title = concert.getTitle();
             this.subTitle = concert.getSubTitle();
-            this.date = concert.getDate().toString();
+            this.startDate = concert.getStartDate().toString();
+            this.endDate = concert.getEndDate().toString();
             this.venueName = concert.getVenueName();
             this.cityName = concert.getCityName();
             this.countryName = concert.getCountryName();

--- a/src/main/java/com/bopcon/backend/dto/UpdateNewConcertRequest.java
+++ b/src/main/java/com/bopcon/backend/dto/UpdateNewConcertRequest.java
@@ -14,7 +14,8 @@ public class UpdateNewConcertRequest {
     private Long artistId;
     private String title;
     private String subTitle;
-    private LocalDate date;
+    private LocalDate startDate;
+    private LocalDate endDate;
     private String venueName; // 공연장
     private String cityName;
     private String countryName; // ex) Republic of Korea

--- a/src/main/java/com/bopcon/backend/service/FavoriteService.java
+++ b/src/main/java/com/bopcon/backend/service/FavoriteService.java
@@ -82,7 +82,8 @@ public class FavoriteService {
                     if (fav.getNewConcert() != null) {
                         response.setNewConcertId(fav.getNewConcert().getNewConcertId());
                         response.setNewConcertTitle(fav.getNewConcert().getTitle());
-                        response.setNewConcertDate(fav.getNewConcert().getDate().toString());
+                        response.setNewConcertDate(fav.getNewConcert().getStartDate().toString());
+                        response.setNewConcertDate(fav.getNewConcert().getEndDate().toString());
                         response.setPosterUrl(fav.getNewConcert().getPosterUrl());
                     }
                     return response;


### PR DESCRIPTION
기존에 날짜를 한 개만 저장하여 양일콘서트 여러일에 걸쳐 콘서트 하는 경우, 나타내는데 문제가 있어

시작날짜와 종료날짜를 저장하여  (25.01.01~25.01.02) 형식으로 나타낼 수 있도록 함