### PR TITLE
api 요청 별 권한 설정, jwt 토큰에 유저 권한을 포함시켜 프론트에서 디코딩하여 사용

### DIFF
--- a/src/main/java/com/bopcon/backend/config/jwt/TokenProvider.java
+++ b/src/main/java/com/bopcon/backend/config/jwt/TokenProvider.java
@@ -43,6 +43,7 @@ public class TokenProvider {
                 .setExpiration(expiry) // 내용 exp(만료일시) : expiry 멤버 변숫값 (토큰의 만료시간 설정)
                 .setSubject(user.getEmail()) // 내용 sub(토큰제목) : 유저의 이메일 (유저 식별 가능케함)
                 .claim("id", user.getId()) // 클레임 id : 유저 ID ( 클레임으로 추가하여, 토큰에서 쉽게 유저 ID를 가져올 수 있게 함)
+                .claim("roles", user.getRoles()) // roles 정보 추가
                 // 서명 : 비밀값과 함께 해시값을 HS256 방식으로 암호화
                 .signWith(SignatureAlgorithm.HS256, jwtProperties.getSecretKey())
                 .compact(); // JWT 토큰을 문자열로 직렬화하여 최종 토큰을 생성
@@ -82,10 +83,10 @@ public class TokenProvider {
                         claims.get("id", Long.class), // ID
                         claims.getSubject(), // 이메일
                         "", // 패스워드
-                        Collections.singleton(new SimpleGrantedAuthority("ROLE_USER"))
+                        Collections.singleton(new SimpleGrantedAuthority(claims.get("roles", String.class)))
                 ),
                 token,
-                Collections.singleton(new SimpleGrantedAuthority("ROLE_USER"))
+                Collections.singleton(new SimpleGrantedAuthority(claims.get("roles", String.class)))
         );
     }
 

--- a/src/main/java/com/bopcon/backend/controller/AdminController.java
+++ b/src/main/java/com/bopcon/backend/controller/AdminController.java
@@ -1,0 +1,18 @@
+package com.bopcon.backend.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/admin")
+@RequiredArgsConstructor
+public class AdminController {
+
+    @GetMapping("/dashboard")
+    public ResponseEntity<String> getDashboard() {
+        return ResponseEntity.ok("Welcome to Admin Dashboard!");
+    }
+}

--- a/src/main/java/com/bopcon/backend/controller/ArtistApiController.java
+++ b/src/main/java/com/bopcon/backend/controller/ArtistApiController.java
@@ -48,7 +48,7 @@ public class ArtistApiController {
     }
 
     // 아티스트 삭제
-    @DeleteMapping("/api/artists/{artistId}")
+    @DeleteMapping("/api/admin/artists/{artistId}")
     public ResponseEntity<Void> deleteArtist(@PathVariable long artistId) {
         artistService.delete(artistId);
 
@@ -63,7 +63,7 @@ public class ArtistApiController {
     }
 
     // 2. 외부 API를 통해 특정 아티스트 데이터 동기화
-    @PostMapping("/api/artists/{mbid}/sync")
+    @PostMapping("/api/admin/artists/{mbid}/sync")
     public ResponseEntity<String> syncArtistData(@PathVariable String mbid) {
         artistService.syncArtistData(mbid);
         return ResponseEntity.ok("Artist data synced successfully");
@@ -83,7 +83,7 @@ public class ArtistApiController {
         return ResponseEntity.ok(setlists);
     }
     // 특정 아티스트의 내한 콘서트 예상 셋리스트 생성
-    @PostMapping("/api/artists/{artistId}/predict-setlist")
+    @PostMapping("/api/admin/artists/{artistId}/predict-setlist")
     public ResponseEntity<String> predictSetlist(@PathVariable Long artistId,
                                                  @RequestParam Long newConcertId) {
         // 1. 과거 셋리스트 데이터를 내부적으로 호출
@@ -104,7 +104,7 @@ public class ArtistApiController {
     }
 
     // 특정 콘서트 예상 셋리스트 조회
-    @GetMapping("/api/concerts/{newConcertId}/predicted-setlist")
+    @GetMapping("/api/new-concerts/{newConcertId}/predicted-setlist")
     public ResponseEntity<List<PredictSetlistDTO>> getPredictedSetlist(@PathVariable Long newConcertId) {
         List<PredictSetlistDTO> predictedSetlist = artistService.getPredictedSetlist(newConcertId);
         return ResponseEntity.ok(predictedSetlist);

--- a/src/main/java/com/bopcon/backend/controller/BoardApiController.java
+++ b/src/main/java/com/bopcon/backend/controller/BoardApiController.java
@@ -19,6 +19,8 @@ import java.util.List;
 @RestController // HTTP Response Body 에 객체 데이터를 JSON 형식으로 반환하는 컨트롤러
 public class BoardApiController {
     private final BoardService boardService;
+
+    //글 등록
     @PostMapping("/api/articles")
     public ResponseEntity<AddArticleResponse> addArticle(
             @RequestBody AddArticleRequest request,
@@ -30,7 +32,6 @@ public class BoardApiController {
         AddArticleResponse response = new AddArticleResponse(savedArticle);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
-
 
     //글 목록 조회
     @GetMapping("/api/articles")

--- a/src/main/java/com/bopcon/backend/domain/User.java
+++ b/src/main/java/com/bopcon/backend/domain/User.java
@@ -34,6 +34,9 @@ public class User implements UserDetails {
     @Column(name = "nickname", nullable = false, unique = true)
     private String nickname;
 
+    @Column(nullable = false) // 일반 계정은 null, 관리자 계정은 'ROLE_ADMIN'
+    private String roles = "ROLE_USER";
+
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
@@ -42,10 +45,11 @@ public class User implements UserDetails {
 
 
     @Builder
-    public User(String email, String password, String nickname) {
+    public User(String email, String password, String nickname, String roles) {
         this.email = email;
         this.password = password;
         this.nickname = nickname;
+        this.roles = roles;
     }
 
     // 새로운 생성자 추가
@@ -53,6 +57,11 @@ public class User implements UserDetails {
         this.id = id;
         this.email = email;
         this.password = password;
+
+        // GrantedAuthority를 기반으로 roles 설정
+        if (authorities != null && !authorities.isEmpty()) {
+            this.roles = authorities.iterator().next().getAuthority(); // 첫 번째 권한을 roles에 설정
+        }
     }
 
 
@@ -74,7 +83,10 @@ public class User implements UserDetails {
     // 권한 반환
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of(new SimpleGrantedAuthority("user"));
+        if (roles != null) {
+            return List.of(new SimpleGrantedAuthority(roles));
+        }
+        return List.of(); // 일반 계정은 빈 권한 목록 반환
     }
 
     // 사용자의 id를 반환(고유 값)

--- a/src/main/java/com/bopcon/backend/dto/NewConcertResponse.java
+++ b/src/main/java/com/bopcon/backend/dto/NewConcertResponse.java
@@ -13,6 +13,7 @@ import java.time.LocalDate;
 public class NewConcertResponse {
     private Long newConcertId;
     private Long artistId;
+    private String artistName;
     private String title;
     private String subTitle;
     private LocalDate startDate;
@@ -32,6 +33,7 @@ public class NewConcertResponse {
         return new NewConcertResponse(
                 newConcert.getNewConcertId(),
                 newConcert.getArtistId() != null ? newConcert.getArtistId().getArtistId() : null, // Null 처리
+                newConcert.getArtistId().getName(),
                 newConcert.getTitle(),
                 newConcert.getSubTitle(),
                 newConcert.getStartDate(),
@@ -52,7 +54,7 @@ public class NewConcertResponse {
     public NewConcertResponse(NewConcert newConcert) {
         this.newConcertId = newConcert.getNewConcertId();
         this.artistId = newConcert.getArtist().getArtistId(); // 처음 get 은 아티스트 객체를 가져오고 두번째는 아이드를 가져옴
-        this.artistId = newConcert.getArtistId() != null ? newConcert.getArtistId().getArtistId() : null; // Null 처리
+        this.artistName = newConcert.getArtist().getName();
         this.title = newConcert.getTitle();
         this.subTitle = newConcert.getSubTitle();
         this.startDate = newConcert.getStartDate();

--- a/src/main/resources/static/admin/admin.js
+++ b/src/main/resources/static/admin/admin.js
@@ -80,7 +80,7 @@ document.getElementById('artist-form').addEventListener('submit', async (e) => {
 // 아티스트 삭제
 async function deleteArtist(artistId) {
     try {
-        const response = await fetch(`/api/artists/${artistId}`, {
+        const response = await fetch(`/api/admin/artists/${artistId}`, {
             method: 'DELETE',
             headers: getHeaders(),
         });


### PR DESCRIPTION
[feat: jwt 토큰에 roles 를 포함하고, 프론트에서 디코딩하여 사용토록 함]
- 클레임에 roles 추가
- 유저엔티티에 roles 추가
- jwt 토큰 생성 시 roles 가 포함 됨

[feat: 시큐리티필터체인 권한 설정]
- 로그인 유저/비로그인 유저의 api 요청 권한 설정
- 즐겨찾기 글쓰기는 로그인 한 유저만 이용가능
- 특정 요청들은 관리자만 이용가능