### PR TITLE
fix/ 리액트 네이티브에서 user_id 받아오게 수정

### DIFF
--- a/src/main/java/com/bopcon/backend/dto/LoginResponse.java
+++ b/src/main/java/com/bopcon/backend/dto/LoginResponse.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public class LoginResponse {
+    private Long id;
     private String accessToken;
     private String nickname;
 }

--- a/src/main/java/com/bopcon/backend/service/AuthService.java
+++ b/src/main/java/com/bopcon/backend/service/AuthService.java
@@ -39,6 +39,7 @@ public class AuthService {
         token.update(refreshToken);
         refreshTokenRepository.save(token);
 
-        return new LoginResponse(accessToken, user.getNickname());
+        // 사용자 ID를 포함하여 반환
+        return new LoginResponse(user.getId(),accessToken, user.getNickname());
     }
 }


### PR DESCRIPTION
리액트 네이티브에서 user_id를 받아와야 게시글 쓸 수 있어서 받아오게 수정했고
수정한 코드가 리액트에서 말썽을 피우지 않음